### PR TITLE
Add new class-based JPEG tests

### DIFF
--- a/test_when_printing_jpeg_2686.py
+++ b/test_when_printing_jpeg_2686.py
@@ -1,0 +1,96 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType, MediaOrientation
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Jpeg test using **2686.jpg
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:2686.jpg=e7a41c713330895d538595fbf74af4f7ac88a25424abb103beb3872d54cc0bfa
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_2686_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_2686
+            +guid:f7701f8a-dafd-4e6b-8850-fee43483fa22
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+    
+
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_2686_then_succeeds(self):
+            if self.print_emulation.print_engine_platform == 'emulator':
+                tray1 = MediaInputIds.Tray1.name
+                if self.tray.is_size_supported('anycustom', 'tray-1'):
+                    self.print_emulation.tray.open(tray1)
+                    self.print_emulation.tray.load(tray1,'Custom', MediaType.Plain.name)
+                    self.print_emulation.tray.close(tray1)
+
+            self.outputsaver.validate_crc_tiff(self.udw)
+            job_id = self.print.raw.start('e7a41c713330895d538595fbf74af4f7ac88a25424abb103beb3872d54cc0bfa')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/test_when_printing_jpeg_9587eb968f64f6d6fc20e5b3d0d71abc.py
+++ b/test_when_printing_jpeg_9587eb968f64f6d6fc20e5b3d0d71abc.py
@@ -1,0 +1,72 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:PostScript high value test using **9587eb968f64f6d6fc20e5b3d0d71abc.jpg
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:9587eb968f64f6d6fc20e5b3d0d71abc.jpg=18f25bed0d24c7ed1203c867676b1d33903edcf6643c77989a31a85721f88357
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_9587eb968f64f6d6fc20e5b3d0d71abc_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_9587eb968f64f6d6fc20e5b3d0d71abc
+            +guid:1d6acf61-ca4a-4ac2-813d-1243a2bc648b
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_9587eb968f64f6d6fc20e5b3d0d71abc_then_succeeds(self):
+            job_id = self.print.raw.start('18f25bed0d24c7ed1203c867676b1d33903edcf6643c77989a31a85721f88357')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()

--- a/test_when_printing_jpeg_corrupted_file.py
+++ b/test_when_printing_jpeg_corrupted_file.py
@@ -1,0 +1,85 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: Simple Print job of Jpeg file of 1MB from **
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:180
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:DatastreamCorrupted.JPG=8569b17b86977b3f02e3c5194d6436df02662bc5724f929f007a1a4626a9f122
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_corrupted_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_corrupted_file
+            +guid:5ae70a25-db13-4b65-bb7c-144ff7550b17
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+    
+
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_corrupted_file_then_succeeds(self):
+            job_id = self.print.raw.start('8569b17b86977b3f02e3c5194d6436df02662bc5724f929f007a1a4626a9f122', expected_job_state='FAILED')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.clear_output()
+            logging.info("Jpeg corrupted file")

--- a/test_when_printing_jpeg_file_example_JPG_100kB.py
+++ b/test_when_printing_jpeg_file_example_JPG_100kB.py
@@ -1,0 +1,91 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg file of 100kB from *file_example_JPG_100kB.jpg
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:360
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:file_example_JPG_100kB.jpg=88aeb1f4467bd1e50cf624de972fbf3f40801632fedb64aaa7b1a8a9ef786fc6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_file_example_JPG_100kB_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_file_example_JPG_100kB
+            +guid:6bcdc78d-42b7-446c-950d-162c8fe43572
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_file_example_JPG_100kB_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+            default = self.tray.get_default_source()
+            media_width_maximum = self.tray.capabilities["supportedInputs"][0]["mediaWidthMaximum"]
+            media_length_maximum = self.tray.capabilities["supportedInputs"][0]["mediaLengthMaximum"]
+            media_width_minimum = self.tray.capabilities["supportedInputs"][0]["mediaWidthMinimum"]
+            media_length_minimum = self.tray.capabilities["supportedInputs"][0]["mediaLengthMinimum"]
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, 'anycustom', 'stationery')
+            elif self.tray.is_size_supported('custom', default) and media_width_maximum > 85000 and media_length_maximum >= 110000 and media_width_minimum < 85000 and media_length_minimum <= 110000:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+            elif self.tray.is_size_supported('na_letter_8.5x11in', default):
+                self.tray.configure_tray(default, 'na_letter_8.5x11in', 'stationery')
+
+            job_id = self.print.raw.start('88aeb1f4467bd1e50cf624de972fbf3f40801632fedb64aaa7b1a8a9ef786fc6', timeout=360)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.tray.reset_trays()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("Jpeg file example JPG 100kB Page - Print job completed successfully")

--- a/test_when_printing_jpeg_file_example_JPG_1MB.py
+++ b/test_when_printing_jpeg_file_example_JPG_1MB.py
@@ -1,0 +1,114 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.print_common_types import MediaType, MediaOrientation
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: Simple Print job of Jpeg file of 1MB from **
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:file_example_JPG_1MB.jpg=683a8528125ca09d8314435c051331de2b4c981c756721a2d12c103e8603a1d2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_file_example_JPG_1MB_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_file_example_JPG_1MB
+            +guid:53177689-80cf-4d01-af66-5985b006b309
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+    
+
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_file_example_JPG_1MB_then_succeeds(self):
+            if self.print_emulation.print_engine_platform == 'emulator' and self.configuration.familyname == 'enterprise':
+                installed_trays = self.print_emulation.tray.get_installed_trays()
+                selected_tray = None
+
+                # Check each tray for supported sizes
+                for tray_id in installed_trays:
+                    system_tray_id = tray_id.lower().replace('tray', 'tray-')
+                    if self.tray.is_size_supported('anycustom', system_tray_id):
+                        selected_tray = tray_id
+                        self.print_emulation.tray.open(selected_tray)
+                        self.print_emulation.tray.load(selected_tray, "Custom", MediaType.Plain.name,
+                                                media_orientation="Portrait")
+                        self.print_emulation.tray.close(selected_tray)
+                        break
+
+                if selected_tray is None:
+                    raise ValueError("No tray found supporting anycustom size")
+            else:
+                default = self.tray.get_default_source()
+                media_width_maximum = self.tray.capabilities["supportedInputs"][0]["mediaWidthMaximum"]
+                media_length_maximum = self.tray.capabilities["supportedInputs"][0]["mediaLengthMaximum"]
+                media_width_minimum = self.tray.capabilities["supportedInputs"][0]["mediaWidthMinimum"]
+                media_length_minimum = self.tray.capabilities["supportedInputs"][0]["mediaLengthMinimum"]
+                if self.tray.is_size_supported('anycustom', default):
+                    self.tray.configure_tray(default, 'anycustom', 'stationery')
+                elif self.tray.is_size_supported('custom', default) and media_width_maximum >= 527777 and media_length_maximum >= 351944 and  media_width_minimum <= 527777 and media_length_minimum <= 351944:
+                    self.tray.configure_tray(default, 'custom', 'stationery') 
+
+            job_id = self.print.raw.start('683a8528125ca09d8314435c051331de2b4c981c756721a2d12c103e8603a1d2', timeout=300)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.tray.reset_trays()
+            logging.info("Jpeg file example JPG 1MB Page - Print job completed successfully")

--- a/test_when_printing_jpeg_file_example_JPG_2500kB.py
+++ b/test_when_printing_jpeg_file_example_JPG_2500kB.py
@@ -1,0 +1,115 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg file of 2500kB from *file_example_JPG_2500kB.jpg
+        +test_tier:1
+        +is_manual:False
+        +test_classification:System
+        +reqid:DUNE-17136
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:file_example_JPG_2500kB.jpg=b6630f7d0ff76f53f21b472f0d383b41a0b8a730a29282f12db435dc390dfdeb
+        +name:TestWhenPrintingJPEGFile::test_when_using_file_example_JPG_2500kB_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_file_example_JPG_2500kB
+            +guid:4c31a2ef-3930-4b2b-acfd-cfb08fc4143d
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+    
+
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_file_example_JPG_2500kB_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+
+            default = self.tray.get_default_source()
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, 'anycustom', 'stationery')
+            elif self.tray.is_size_supported('na_letter_8.5x11in', default):
+                self.tray.configure_tray(default, 'na_letter_8.5x11in', 'stationery')
+
+            # Not using print_verify for a reason
+            # We want to handle media mismatch alert on roll products before job completion
+            jobid = printjob.start_print('b6630f7d0ff76f53f21b472f0d383b41a0b8a730a29282f12db435dc390dfdeb')
+
+            # This jpeg job has large dimensions
+            # On non-roll products, it will print on Letter
+            if 'main-roll' in self.tray.trays:
+                # On Beam, it will print on main-roll after out of range media check clipping target size leading to a prompt
+                self.media.wait_for_alerts('mediaMismatchUnsupportedSize', 100)
+                # Handle the prompt displayed to user to continue printing
+                self.media.alert_action('mediaMismatchUnsupportedSize', 'continue')
+            elif 'roll-1' in self.tray.trays:
+                # Apply same workaround for multi-roll products, alert is mediaMismatchSizeFlow
+                self.media.wait_for_alerts('mediaMismatchSizeFlow', 100)
+                self.media.alert_action("mediaMismatchSizeFlow", "continue")
+
+
+            jobstate = printjob.wait_verify_job_completion(jobid, timeout=600)
+
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+            self.tray.reset_trays()
+
+            logging.info("Jpeg file example JPG 2500kB Page - Print job completed successfully")

--- a/test_when_printing_jpeg_file_example_JPG_500kB.py
+++ b/test_when_printing_jpeg_file_example_JPG_500kB.py
@@ -1,0 +1,74 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg file of 500kB from *file_example_JPG_500kB.jpg
+        +test_tier:1
+        +is_manual:False
+        +test_classification:System
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:file_example_JPG_500kB.jpg=838e346997ab5f2dd6745e9e536de6f9cd68965088354597f2fba016ad40ab2c
+        +name:TestWhenPrintingJPEGFile::test_when_using_file_example_JPG_500kB_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_file_example_JPG_500kB
+            +guid:7b6cd377-7f1b-4dca-a16e-75ade8d88de5
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_file_example_JPG_500kB_then_succeeds(self):
+            job_id = self.print.raw.start('838e346997ab5f2dd6745e9e536de6f9cd68965088354597f2fba016ad40ab2c')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            logging.info("Jpeg file example JPG 500kB Page - Print job completed successfully")

--- a/test_when_printing_jpeg_low_resolution.py
+++ b/test_when_printing_jpeg_low_resolution.py
@@ -1,0 +1,91 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Jpeg test using **Low_Resolution.jpg
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:Low_Resolution.jpg=c8c83c0ed7b494873b33ce156398af91d873f8317276b8055ccb0022d8f1b398
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_low_resolution_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_low_resolution
+            +guid:0fd5df30-f506-4d58-a5d0-66c9009c2bf1
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+    
+
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_low_resolution_then_succeeds(self):
+            # Setting udw command for crc to true for generating pdl crc after print job done
+            self.outputsaver.validate_crc_tiff(self.udw)
+
+            job_id = self.print.raw.start('c8c83c0ed7b494873b33ce156398af91d873f8317276b8055ccb0022d8f1b398')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/test_when_printing_jpeg_no_resolution_in_file.py
+++ b/test_when_printing_jpeg_no_resolution_in_file.py
@@ -1,0 +1,90 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Test jpeg job when no resolution in specified in file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-215024
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:road_nores.jpeg=116ef2798a4d195fd1e3ea20d81af3b8c20373587e119d10a6ff0f0d70ee6f86
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_no_resolution_in_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_no_resolution_in_file
+            +guid:ea4d4400-4e5e-48a5-b30b-210e575a7ca3
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG & EngineFirmwareFamily=DoX & PrintResolution=Print300
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_no_resolution_in_file_then_succeeds(self):
+            self.tray.reset_trays()
+            default_tray = self.tray.get_default_source()
+            if self.tray.is_size_supported('custom', default_tray):
+                self.tray.configure_tray(default_tray, 'custom', 'stationery')
+
+            self.outputsaver.validate_crc_tiff(self.udw)
+
+            job_id = self.print.raw.start('116ef2798a4d195fd1e3ea20d81af3b8c20373587e119d10a6ff0f0d70ee6f86', 'SUCCESS', 300, 1)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputverifier.save_and_parse_output()
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            self.outputverifier.verify_resolution(Intents.printintent, 600)
+            self.outputverifier.verify_page_width(Intents.printintent, 3000)
+            self.outputverifier.verify_page_height(Intents.printintent, 3749)
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()

--- a/test_when_printing_jpeg_out_of_range_behavior.py
+++ b/test_when_printing_jpeg_out_of_range_behavior.py
@@ -1,0 +1,105 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Test jpeg out of range behavior on roll
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-155289
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:A0-600-L.jpg=b9d02741fadecd94d682bb8b40ec433f5ab27ef63418cdcea21085d7b4e89d90
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_out_of_range_behavior_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_out_of_range_behavior_on_roll
+            +guid:0ef9c857-0d81-488b-9a31-13e401744536
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG & PrintProtocols=IPP & MediaInputInstalled=MainRoll & MediaInputInstalled=Main
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_out_of_range_behavior_then_succeeds(self):
+            self.tray.unload_media()
+
+            #Input document is landscape A0 size. It will be printed on roll by rotating it to portrait.
+            ipp_test_attribs = {
+                'document-format': 'image/jpeg',
+                'media-size-name': 'iso_a0_841x1189mm',
+                'media-source': 'main-roll'
+            }
+
+            ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+            jobid = printjob.start_ipp_print(ipp_test_file, 'b9d02741fadecd94d682bb8b40ec433f5ab27ef63418cdcea21085d7b4e89d90')
+
+            if self.tray.is_size_supported('iso_a0_841x1189mm', 'main-roll'):
+                self.media.wait_for_alerts('mediaLoadFlow', 100)
+                self.tray.configure_tray('main-roll', 'iso_a0_841x1189mm', 'stationery')
+                self.tray.load_media('main-roll')
+                self.media.alert_action('mediaLoadFlow', 'ok')
+
+            printjob.wait_verify_job_completion(jobid, "SUCCESS", timeout=300)
+
+            self.outputverifier.save_and_parse_output()
+            self.tray.reset_trays()
+            self.tray.unload_media()  # Will unload self.media from all trays
+            self.tray.load_media()  # Will load self.media in all trays to default
+
+            self.outputverifier.verify_media_source(Intents.printintent, MediaSource.mainroll)
+            self.outputverifier.verify_media_size(Intents.printintent, MediaSize.a0)
+
+            # CRC check
+            self.outputsaver.operation_mode('TIFF')
+            self.outputsaver.validate_crc_tiff(self.udw)
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+            self.outputsaver.operation_mode('NONE')

--- a/test_when_printing_jpeg_pdlmh_printableheight_zero.py
+++ b/test_when_printing_jpeg_pdlmh_printableheight_zero.py
@@ -1,0 +1,85 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Event code via JPEG verysmall.jpg file
+        +test_tier: 1
+        +is_manual:False
+        +test_classification:System
+        +reqid:DUNE-24060
+        +timeout:360
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:verysmall.jpg=fc878bdbba4f8f6d58eaa76d28459fbbe4ef400a43eb85f43933245c3271a163
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdlmh_printableheight_zero_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_pdlmh_printableheight_zero
+            +guid:a9d16111-8a77-4e4b-9282-c1624206c64e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=JPEG & EngineFirmwareFamily=Canon
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_pdlmh_printableheight_zero_then_succeeds(self):
+            job_id = self.print.raw.start('fc878bdbba4f8f6d58eaa76d28459fbbe4ef400a43eb85f43933245c3271a163')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            event_code = "F0.01.08.1B"
+            response = self.cdm.get_raw(self.cdm.WARNING_EVENT_LOG_ENDPOINT)
+            warning_events = response.json().get("events", [])
+
+            event_found = False
+
+            if warning_events is None:
+                print("Test Failed: Event code not found.")
+
+            for event in warning_events:
+                if event.get("eventCode") == event_code:
+                    event_found = True
+                    break 
+
+            assert event_found, f"Test Failed: Event code {event_code} not found."
+            print("Test Passed: Event code found.")

--- a/test_when_printing_jpeg_pdlmh_printablewidth_zero.py
+++ b/test_when_printing_jpeg_pdlmh_printablewidth_zero.py
@@ -1,0 +1,88 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+def clear_and_verify_event_cleared(udw,expected_events):
+    eng = engine.Enginelib(self.udw)
+    assert expected_events == eng.getNewEventsLogged(cleared_event_log), "Event is not cleared successfully"
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Event code via JPEG verysmall.jpg file
+        +test_tier: 1
+        +is_manual:False
+        +test_classification:System
+        +reqid:DUNE-24060
+        +timeout:360
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:verysmall.jpg=fc878bdbba4f8f6d58eaa76d28459fbbe4ef400a43eb85f43933245c3271a163
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdlmh_printablewidth_zero_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_pdlmh_printablewidth_zero
+            +guid:4d21efa6-1e37-41a5-aedd-4f382a164cc2
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=JPEG & EngineFirmwareFamily=Canon
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_pdlmh_printablewidth_zero_then_succeeds(self):
+            job_id = self.print.raw.start('fc878bdbba4f8f6d58eaa76d28459fbbe4ef400a43eb85f43933245c3271a163')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            event_code = "F0.01.08.1C"
+            response = self.cdm.get_raw(self.cdm.WARNING_EVENT_LOG_ENDPOINT)
+            warning_events = response.json().get("events", [])
+
+            event_found = False
+
+            if warning_events is None:
+                print("Test Failed: Event code not found.")
+
+            for event in warning_events:
+                if event.get("eventCode") == event_code:
+                    event_found = True
+                    break 
+
+            assert event_found, f"Test Failed: Event code {event_code} not found."
+            print("Test Passed: Event code found.")

--- a/test_when_printing_jpeg_performance_10_2000cm.py
+++ b/test_when_printing_jpeg_performance_10_2000cm.py
@@ -1,0 +1,86 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg Performance of 10_2000cm Page from *10_2000cm.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:360
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:10_2000cm.jpg=c99290a709203b35b2e7c8520e9764b1648ec79354af4bddfa7aa14b52848dad
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_performance_10_2000cm_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_performance_10_2000cm
+            +guid:e74d7487-1394-4f89-9dd5-0241be6577d3
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG & MediaSizeSupported=Letter
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_performance_10_2000cm_then_succeeds(self):
+
+            # Not using print_verify for a reason
+            # We want to handle media mismatch alert on design products before job completion
+            jobid = printjob.start_print('c99290a709203b35b2e7c8520e9764b1648ec79354af4bddfa7aa14b52848dad')
+
+            # This jpeg job has large dimensions
+            # On non-multiroll products, it will print on Letter
+            if 'roll-1' in self.tray.trays:
+                # On multi-roll, it will print on roll-1 after out of range media check clipping target size leading to a prompt
+                # required rendering time will be bigger
+                self.media.wait_for_alerts('mediaMismatchSizeFlow', 300)
+                self.media.alert_action("mediaMismatchSizeFlow", "continue")
+
+            # for non design products total test timeout will be 240
+            # for design 300
+            printjob.wait_verify_job_completion(jobid, timeout=240)
+
+            logging.info("JPEG Performance 10_2000cm Page - Print job completed successfully")

--- a/test_when_printing_jpeg_performance_faces.py
+++ b/test_when_printing_jpeg_performance_faces.py
@@ -1,0 +1,90 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg Performance faces Page from *faces.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:faces.jpg=d625c95d10545cc5aa1e4ce2f276a7d423c1aa96a683a581a4bc243ee93393a2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_performance_faces_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_performance_faces
+            +guid:ce9d3634-9479-49b4-ae36-faad45aca0c1
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+        +overrides:
+            +Home:
+                +is_manual:False
+                +timeout:240
+                +test:
+                    +dut:
+                        +type:Engine
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_performance_faces_then_succeeds(self):
+            job_id = self.print.raw.start('d625c95d10545cc5aa1e4ce2f276a7d423c1aa96a683a581a4bc243ee93393a2')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            logging.info("JPEG Performance faces Page - Print job completed successfully")

--- a/test_when_printing_jpeg_performance_village.py
+++ b/test_when_printing_jpeg_performance_village.py
@@ -1,0 +1,83 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:C52178012 Simple print job of Jpeg Performance of village Page from *village.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:village.jpg=ff0629b82de8d14c732795720966dfa96a8c8231553415c175af735ce47a0ef5
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_performance_village_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_performance_village
+            +guid:236c60a1-d6fb-4fc0-8f6e-3da065dbf5a7
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+        +overrides:
+            +Home:
+                +is_manual:False
+                +timeout:300
+                +test:
+                    +dut:
+                        +type:Engine
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_performance_village_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+            job_id = self.print.raw.start('ff0629b82de8d14c732795720966dfa96a8c8231553415c175af735ce47a0ef5')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc() 
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+            logging.info("JPEG Performance village Page - Print job completed successfully")

--- a/test_when_printing_jpeg_print_multiple_jobs.py
+++ b/test_when_printing_jpeg_print_multiple_jobs.py
@@ -1,0 +1,105 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+from dunetuf.localization.LocalizationHelper import LocalizationHelper
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Test print multiple jobs
+        +test_tier:1
+        +is_manual:False
+        +reqid:LFPSWQAA-6717
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ProductQA
+        +test_framework:TUF
+        +external_files:lenna_without_resolution_info_EXIF_NONE.jpg=0bfd0d031132cc8326b33ae0aaeff9df4d1fe2ddcf42c208c2842a80ae922c19
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_print_multiple_jobs_then_succeeds
+        +test:
+            +title:test_jpeg_print_multiple_jobs
+            +guid:b5ce7f6f-5f5a-4893-9141-65ff8db2aeae
+            +dut:
+                +type:Simulator, Emulator
+                +configuration:DocumentFormat=JPEG & PrintEngineType=Maia
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_print_multiple_jobs_then_succeeds(self):
+
+            # Go to Job Queue App screen
+            self.spice.cleanSystemEventAndWaitHomeScreen()
+            self.spice.main_app.get_home()
+            self.spice.main_app.goto_job_queue_app()
+
+            # Send job to print
+            printjob.start_print('0bfd0d031132cc8326b33ae0aaeff9df4d1fe2ddcf42c208c2842a80ae922c19')
+
+            # Get last job in queue by CDM
+            queue = self.job.get_job_queue()
+            first_job_id = queue[-1]["jobId"]
+
+            # Send job to print
+            printjob.start_print('0bfd0d031132cc8326b33ae0aaeff9df4d1fe2ddcf42c208c2842a80ae922c19')
+
+            # Get last job in queue by CDM
+            queue = self.job.get_job_queue()
+            second_job_id = queue[-1]["jobId"]
+
+            # Send job to print
+            printjob.start_print('0bfd0d031132cc8326b33ae0aaeff9df4d1fe2ddcf42c208c2842a80ae922c19')
+
+            # Get last job in queue by CDM
+            queue = self.job.get_job_queue()
+            third_job_id = queue[-1]["jobId"]
+
+            #Wait for first job completion
+            self.job.wait_for_job_completion_cdm(first_job_id)
+            self.spice.job_ui.goto_job(first_job_id)
+            assert self.spice.job_ui.recover_job_status() == LocalizationHelper.get_string_translation(self.net,"cJobStateTypeCompleted", self.locale)
+
+            #Wait for second job completion
+            self.job.wait_for_job_completion_cdm(second_job_id)
+            self.spice.job_ui.goto_job(second_job_id)
+            assert self.spice.job_ui.recover_job_status() == LocalizationHelper.get_string_translation(self.net,"cJobStateTypeCompleted", self.locale)
+
+            #Wait for third job completion
+            self.job.wait_for_job_completion_cdm(third_job_id)
+            self.spice.job_ui.goto_job(third_job_id)
+            assert self.spice.job_ui.recover_job_status() == LocalizationHelper.get_string_translation(self.net,"cJobStateTypeCompleted", self.locale)
+
+            # Go to homescreen
+            self.spice.goto_homescreen()

--- a/test_when_printing_jpeg_printfromusb_custom.py
+++ b/test_when_printing_jpeg_printfromusb_custom.py
@@ -1,0 +1,128 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+@pytest.fixture(autouse=True)
+def setup_teardown_pdl_test(job, usbdevice):
+    #override setup to prevent reset of roll length
+    if not self.usbdevice.devices('frontUsb'):
+        logging.info('Adding USB mock device')
+        self.usbdevice.add_mock_device('usbdisk1', 'UsbDisk1', 'frontUsb')
+    logging.info("Cancel all active jobs")
+    self.job.cancel_active_jobs()
+    logging.info("Wait for no active jobs")
+    self.job.wait_for_no_active_jobs()
+    yield
+    if self.usbdevice.check_device('usbdisk1'):
+        self.usbdevice.remove_mock_device('usbdisk1')
+    logging.info("Cancel all active jobs")
+    self.job.cancel_active_jobs()
+    logging.info("Wait for no active jobs")
+    self.job.wait_for_no_active_jobs()
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: Test Print From Thumb drive for jpeg file with Custom size configured
+        +test_tier:1
+        +is_manual:False
+        +test_classification:System
+        +reqid: DUNE-218422
+        +timeout: 600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:5x7in_1_1006.jpg=0fdbac1601827141ec0cb70960c57ea887089bd65b60dde7f0d4ddeb7841bc84
+        +name:TestWhenPrintingJPEGFile::test_when_using_printfromusb_custom_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_jpeg_printfromusb_custom
+            +guid:299df654-1118-4aa4-ab6f-a1415c101b92
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=JPEG & DeviceFunction=PrintFromUsb & ConsumableSupport=Ink & MediaInputInstalled=Tray1
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_printfromusb_custom_then_succeeds(self):
+            # Upload required images to simulated usb device
+            self.outputsaver.operation_mode('CRC')
+            usbroot = self.usbdevice.get_root('usbdisk1')
+            filepath = self.usbdevice.upload('0fdbac1601827141ec0cb70960c57ea887089bd65b60dde7f0d4ddeb7841bc84', usbroot)
+
+            logging.info('Creating print from USB job ticket')
+            resource = {'src': {'usb': {}}, 'dest': {'print': {}}}
+            ticketId = self.job.create_job_ticket(resource)
+
+            default = self.tray.get_default_source()
+            mediasize = 'custom'
+            if self.tray.is_size_supported('na_5x7_5x7in', default):
+                self.tray.configure_tray(default, 'na_5x7_5x7in', 'stationery')
+
+            resource = {
+                'src': {
+                    'usb': {'path': filepath}
+                },
+                'dest': {
+                    'print': {
+                        'mediaSource': default,
+                        'mediaSize': mediasize,
+                        'mediaType': 'stationery',
+                    }
+                },
+                }
+
+            logging.info('Updating print from USB job ticket with source and destination')
+            self.job.update_job_ticket(ticketId, resource)
+
+            logging.info('Create a print job and retrieve print job id')
+            jobId = self.job.create_job(ticketId)
+
+            logging.info('Initialize and start the print job - %s', jobId)
+            self.job.change_job_state(jobId, 'initialize', 'initializeProcessing')
+            self.job.check_job_state(jobId, 'ready', 30)
+            self.job.change_job_state(jobId, 'start', 'startProcessing')
+
+            jobstate = self.job.wait_for_job_completion_cdm(jobId, 120)
+            expected_crc = ["0x5d91f7bc"]
+            self.outputsaver.verify_output_crc(expected_crc)
+
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            assert 'success' in jobstate, 'Unexpected final job state!'

--- a/test_when_printing_jpeg_regression_3Dgirls_JFIF_nounits_without_EXIF.py
+++ b/test_when_printing_jpeg_regression_3Dgirls_JFIF_nounits_without_EXIF.py
@@ -1,0 +1,74 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg Regression of 3Dgirls JFIF nounits without EXIF Page from *3Dgirls_JFIF_nounits_without_EXIF.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:180
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:3Dgirls_JFIF_nounits_without_EXIF.jpg=07010aa839653b2355047c770f6f3631997e0e9172537141d42d185c34f39a1d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_regression_3Dgirls_JFIF_nounits_without_EXIF_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_regression_3Dgirls_JFIF_nounits_without_EXIF
+            +guid:6a3dbb50-1640-48d6-a758-49b38146be07
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_regression_3Dgirls_JFIF_nounits_without_EXIF_then_succeeds(self):
+            job_id = self.print.raw.start('07010aa839653b2355047c770f6f3631997e0e9172537141d42d185c34f39a1d', timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            logging.info("JPEG Regression 3Dgirls JFIF nounits without EXIF Page - Print job completed successfully")

--- a/test_when_printing_jpeg_regression_AdobeRGB_A4_100dpi.py
+++ b/test_when_printing_jpeg_regression_AdobeRGB_A4_100dpi.py
@@ -1,0 +1,100 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg Regression of AdobeRGB A4 100dpi Page from *AdobeRGB_A4_100dpi.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:AdobeRGB_A4_100dpi.jpg=acc8383b0992e875904aa4c196a4f0ef47ba8e0bfdd0914159876e64f79d2700
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_regression_AdobeRGB_A4_100dpi_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_regression_AdobeRGB_A4_100dpi
+            +guid:d059ea34-de28-4e32-bf36-be98412358c0
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_regression_AdobeRGB_A4_100dpi_then_succeeds(self):
+            if self.outputsaver.configuration.productname == "jupiter":
+                self.outputsaver.operation_mode('CRC')
+            else:
+                self.outputsaver.operation_mode('TIFF')
+                self.outputsaver.validate_crc_tiff(self.udw)
+
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('acc8383b0992e875904aa4c196a4f0ef47ba8e0bfdd0914159876e64f79d2700', timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+
+            self.outputsaver.save_output()
+            if self.outputsaver.configuration.productname == "jupiter":
+                expected_crc = ["0x9350fdc4"]
+                self.outputsaver.verify_output_crc(expected_crc)
+            else:
+                Current_crc_value = self.outputsaver.get_crc()
+                logging.info("Validate current crc with master crc")
+                assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+
+            logging.info("JPEG Regression AdobeRGB A4 100dpi Page - Print job completed successfully")

--- a/test_when_printing_jpeg_regression_BGR_A4_100dpi.py
+++ b/test_when_printing_jpeg_regression_BGR_A4_100dpi.py
@@ -1,0 +1,90 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.print_common_types import MediaSize, MediaType
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg Regression of BGR A4 100dpi Page from *BGR_A4_100dpi.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:420
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:BGR_A4_100dpi.jpg=04e30e1847278cbccc57f4ac8cc64e657922b47be63fd42874311b453c629f7b
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_regression_BGR_A4_100dpi_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_regression_BGR_A4_100dpi
+            +guid:14d98627-99dc-496d-b8af-dbf5dd5c330e
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_regression_BGR_A4_100dpi_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+            default = self.tray.get_default_source()
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+            elif self.tray.is_size_supported('any', default):
+                tray_test_name = self.print_mapper.get_media_input_test_name(default)
+                self.print_emulation.tray.setup_tray(tray_test_name, MediaSize.Letter.name, MediaType.Plain.name)
+                self.tray.configure_tray(default, 'any', 'any')
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('04e30e1847278cbccc57f4ac8cc64e657922b47be63fd42874311b453c629f7b',timeout=420)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.tray.reset_trays()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG Regression BGR A4 100dpi Page - Print job completed successfully")

--- a/test_when_printing_jpeg_regression_SWOP_A4_100dpi.py
+++ b/test_when_printing_jpeg_regression_SWOP_A4_100dpi.py
@@ -1,0 +1,100 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg Regression of SWOP A4 100dpi Page from *SWOP_A4_100dpi.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:SWOP_A4_100dpi.jpg=42cf76c1cbe4f91f5f557ffd6670c3438ed8611c5956d3aefcdf5274e3c83193
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_regression_SWOP_A4_100dpi_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_regression_SWOP_A4_100dpi
+            +guid:e59d7529-77be-493a-b874-7929a5b73ff8
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_regression_SWOP_A4_100dpi_then_succeeds(self):
+            if self.outputsaver.configuration.productname == "jupiter":
+                self.outputsaver.operation_mode('CRC')
+            else:
+                self.outputsaver.operation_mode('TIFF')
+                self.outputsaver.validate_crc_tiff(self.udw)
+
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('42cf76c1cbe4f91f5f557ffd6670c3438ed8611c5956d3aefcdf5274e3c83193', timeout=120)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+
+            self.outputsaver.save_output()
+            if self.outputsaver.configuration.productname == "jupiter":
+                expected_crc = ["0xec6ce0e1"]
+                self.outputsaver.verify_output_crc(expected_crc)
+            else:
+                Current_crc_value = self.outputsaver.get_crc()
+                logging.info("Validate current crc with master crc")
+                assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+
+            logging.info("JPEG Regression SWOP A4 100dpi Page - Print job completed successfully")

--- a/test_when_printing_jpeg_regression_faces_small.py
+++ b/test_when_printing_jpeg_regression_faces_small.py
@@ -1,0 +1,81 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg Regression of faces small Page from *faces_small.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:faces_small.jpg=19d6b2e4af3faca6ef1c95c5750a3c8dea079b14a04a061cf4d2acdfaf2cb9fc
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_regression_faces_small_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_regression_faces_small
+            +guid:453ce495-4ba2-4346-baac-ad7e685693e0
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_regression_faces_small_then_succeeds(self):
+            default = self.tray.get_default_source()
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, 'anycustom', 'stationery')
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('19d6b2e4af3faca6ef1c95c5750a3c8dea079b14a04a061cf4d2acdfaf2cb9fc')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.tray.reset_trays()
+
+            logging.info("JPEG Regression faces small Page - Print job completed successfully")

--- a/test_when_printing_jpeg_regression_sRGB_A4_100dpi.py
+++ b/test_when_printing_jpeg_regression_sRGB_A4_100dpi.py
@@ -1,0 +1,97 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg Regression of sRGB A4 100dpi Page from *sRGB_A4_100dpi.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:420
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:sRGB_A4_100dpi.jpg=1ba0f46f30adf9190185558010124bf32a1a432ba8aefd131d9c26bf9b050b09
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_regression_sRGB_A4_100dpi_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_regression_sRGB_A4_100dpi
+            +guid:e1b13932-8fcf-4fed-a6a5-7cd036379fb9
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_regression_sRGB_A4_100dpi_then_succeeds(self):
+            if self.outputsaver.configuration.productname == "jupiter":
+                self.outputsaver.operation_mode('CRC')
+            else:
+                self.outputsaver.operation_mode('TIFF')
+                self.outputsaver.validate_crc_tiff(self.udw)
+            default = self.tray.get_default_source()
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('1ba0f46f30adf9190185558010124bf32a1a432ba8aefd131d9c26bf9b050b09',timeout=420)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+
+            self.outputsaver.save_output()
+            if self.outputsaver.configuration.productname == "jupiter":
+                expected_crc = ["0x8e95a11b"]
+                self.outputsaver.verify_output_crc(expected_crc)
+            else:
+                Current_crc_value = self.outputsaver.get_crc()
+                logging.info("Validate current crc with master crc")
+                assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+
+            logging.info("JPEG Regression sRGB A4 100dpi Page - Print job completed successfully")

--- a/test_when_printing_jpeg_regression_untagged_argb_100dpi.py
+++ b/test_when_printing_jpeg_regression_untagged_argb_100dpi.py
@@ -1,0 +1,144 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.print_common_types import MediaSize, MediaType
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:C52178011 Simple print job of Jpeg Regression of untagged argb 100dpi Page from *untagged_argb_100dpi.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:400
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:untagged_argb_100dpi.jpg=d91801b4c08f2ed918a3cbf885a61c8721cace99b0e83a2f82e95660e2275704
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_regression_untagged_argb_100dpi_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_regression_untagged_argb_100dpi
+            +guid:27528ced-c583-4fea-bad4-4f1bc5120fc5
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+            +ProA4:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+        +overrides:
+            +Home:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Engine
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_regression_untagged_argb_100dpi_then_succeeds(self):
+            if self.outputsaver.configuration.productname == "jupiter":
+                self.outputsaver.operation_mode('CRC')
+            else:
+                self.outputsaver.operation_mode('TIFF')
+
+            if self.print_emulation.print_engine_platform == 'emulator':
+                installed_trays = self.print_emulation.tray.get_installed_trays()
+                selected_tray = None
+
+                # Check each tray for supported sizes
+                for tray_id in installed_trays:
+                    system_tray_id = tray_id.lower().replace('tray', 'tray-')
+                    if self.tray.is_size_supported('anycustom', system_tray_id):
+                        selected_tray = tray_id
+                        self.print_emulation.tray.open(selected_tray)
+                        self.print_emulation.tray.load(selected_tray, "Custom", MediaType.Plain.name,
+                                                media_orientation="Portrait")
+                        self.print_emulation.tray.close(selected_tray)
+                        break
+
+                if selected_tray is None:
+                    raise ValueError("No tray found supporting anycustom size")
+            else:
+                default = self.tray.get_default_source()
+                if self.tray.is_size_supported('any', default):
+                    tray_test_name = self.print_mapper.get_media_input_test_name(default)
+                    self.print_emulation.tray.setup_tray(tray_test_name, MediaSize.Letter.name, MediaType.Plain.name)
+                    self.tray.configure_tray(default, 'any', 'any')
+                elif self.tray.is_size_supported('anycustom', default):
+                    self.tray.configure_tray(default, "anycustom", 'stationery')
+                else:
+                    media_width_maximum = self.tray.capabilities["supportedInputs"][0]["mediaWidthMaximum"]
+                    media_length_maximum = self.tray.capabilities["supportedInputs"][0]["mediaLengthMaximum"]
+                    media_width_minimum = self.tray.capabilities["supportedInputs"][0]["mediaWidthMinimum"]
+                    media_length_minimum = self.tray.capabilities["supportedInputs"][0]["mediaLengthMinimum"]
+                    if self.tray.is_size_supported('custom', default) and media_width_maximum >= 527777 and media_length_maximum >= 351944 and media_width_minimum <= 527777 and media_length_minimum <= 351944:
+                        self.tray.configure_tray(default, 'custom', 'stationery')
+                    else:
+                        self.tray.configure_tray(default, 'custom', 'stationery')
+
+            self.outputsaver.validate_crc_tiff(self.udw) 
+            job_id = self.print.raw.start('d91801b4c08f2ed918a3cbf885a61c8721cace99b0e83a2f82e95660e2275704',timeout=360)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+
+            self.outputsaver.save_output()
+            if self.outputsaver.configuration.productname == "jupiter":
+                expected_crc = ["0x9350fdc4"]    
+                self.outputsaver.verify_output_crc(expected_crc)
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc() 
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+
+            logging.info("JPEG Regression untagged argb 100dpi Page - Print job completed successfully")

--- a/test_when_printing_jpeg_regression_untagged_cmyk_swop_100dpi.py
+++ b/test_when_printing_jpeg_regression_untagged_cmyk_swop_100dpi.py
@@ -1,0 +1,100 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg Regression of untagged cmyk swop 100dpi Page from *untagged_cmyk_swop_100dpi.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:untagged_cmyk_swop_100dpi.jpg=4f9f5dd2775a1a4a733a6a21830b4b257bab151d6971ee664e482c67013d7cda
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_regression_untagged_cmyk_swop_100dpi_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_regression_untagged_cmyk_swop_100dpi
+            +guid:c326aa1f-e413-4643-804c-d67cd12039b3
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_regression_untagged_cmyk_swop_100dpi_then_succeeds(self):
+            if self.outputsaver.configuration.productname == "jupiter":
+                self.outputsaver.operation_mode('CRC')
+            else:
+                self.outputsaver.operation_mode('TIFF')
+                self.outputsaver.validate_crc_tiff(self.udw)
+
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('4f9f5dd2775a1a4a733a6a21830b4b257bab151d6971ee664e482c67013d7cda',timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+
+            self.outputsaver.save_output()
+            if self.outputsaver.configuration.productname == "jupiter":
+                expected_crc = ["0x1408b886"]
+                self.outputsaver.verify_output_crc(expected_crc)
+            else:
+                Current_crc_value = self.outputsaver.get_crc()
+                logging.info("Validate current crc with master crc")
+                assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+
+            logging.info("JPEG Regression untagged cmyk swop 100dpi Page - Print job completed successfully")

--- a/test_when_printing_jpeg_sRGB_A4_600dpi.py
+++ b/test_when_printing_jpeg_sRGB_A4_600dpi.py
@@ -1,0 +1,75 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of jpeg_sRGB_A4_600dpi
+        +test_tier:1
+        +is_manual:True
+        +reqid:DUNE-18107
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:LFP_PrintWorkflows
+        +test_framework:TUF
+        +external_files:sRGB_A4_600dpi.jpg=86c81bfee5d3a323f7faf4026db8bf534e9d8edf624b9170bb60e3cf2d59773b
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_sRGB_A4_600dpi_then_succeeds
+        +test:
+            +title:test_jpeg_sRGB_A4_600dpi
+            +guid:3a68798d-0c81-49dc-a406-ded51389d2a1
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_sRGB_A4_600dpi_then_succeeds(self):
+            self.outputsaver.operation_mode('TIFF')
+
+            default = self.tray.get_default_source()
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, 'anycustom', 'stationery')
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('86c81bfee5d3a323f7faf4026db8bf534e9d8edf624b9170bb60e3cf2d59773b', timeout=300)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+
+            logging.info("Jpeg sRGB_A4_600dpi- Print job completed successfully")

--- a/test_when_printing_jpeg_sRGB_A4_600dpi_checksum.py
+++ b/test_when_printing_jpeg_sRGB_A4_600dpi_checksum.py
@@ -1,0 +1,75 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.utility.systemtestpath import get_system_test_binaries_path
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: Print job file *sRGB_A4_600dpi.jpg
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:LFP_PrintWorkflows
+        +test_framework:TUF
+        +external_files:sRGB_A4_600dpi.jpg=86c81bfee5d3a323f7faf4026db8bf534e9d8edf624b9170bb60e3cf2d59773b
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_sRGB_A4_600dpi_checksum_then_succeeds
+        +test:
+            +title:test_jpg_sRGB_A4_600dpi_checksum
+            +guid:3a942ee5-f517-4493-9bc1-9a4f0a2dc1c0
+            +dut:
+                +type:Simulator, Emulator
+                +configuration:PrintEngineType=Maia & DocumentFormat=JPEG
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_sRGB_A4_600dpi_checksum_then_succeeds(self):
+
+            # CRC will be calculated using the payload of all the RasterDatas
+            self.outputsaver.operation_mode('CRC')
+
+            job_id = self.print.raw.start('86c81bfee5d3a323f7faf4026db8bf534e9d8edf624b9170bb60e3cf2d59773b', timeout=300)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            logging.info("basic file sRGB_A4_600dpi.jpg - Print job completed successfully")
+
+            expected_crc = ["0x35d1f2ef"]
+
+            # Read and verify that obtained checksums are the expected ones
+            self.outputsaver.save_output()
+            self.outputsaver.verify_output_crc(expected_crc)
+            logging.info("basic file sRGB_A4_600dpi.jpg - Checksum(s) verified successfully")

--- a/test_when_printing_jpeg_smalljob_on_largepaper.py
+++ b/test_when_printing_jpeg_smalljob_on_largepaper.py
@@ -1,0 +1,100 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Test jpeg small job on large paper tray
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-153638
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:abbey-4x6-L.jpg=1fcc44e51d4702a75c0487be852ae62fca82a2cab4bf0d19645b83e3264eb1d0
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_smalljob_on_largepaper_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_smalljob_on_largepaper_on_tray
+            +guid:2590acaa-905d-4eb9-b431-47a7bf4f4e5e
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG & PrintProtocols=IPP & MediaInputInstalled=MainRoll & MediaInputInstalled=Main
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_smalljob_on_largepaper_then_succeeds(self):
+            self.tray.unload_media()
+            if self.tray.is_size_supported('iso_a4_210x297mm', 'main'):
+                self.tray.configure_tray('main', 'iso_a4_210x297mm', 'stationery')
+                self.tray.load_media('main')
+
+            ipp_test_attribs = {
+                'document-format': 'image/jpeg',
+                'media-source': 'main'
+            }
+
+            ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+            jobid = printjob.start_ipp_print(ipp_test_file, '1fcc44e51d4702a75c0487be852ae62fca82a2cab4bf0d19645b83e3264eb1d0')
+
+            printjob.wait_verify_job_completion(jobid, "SUCCESS", timeout=180)
+
+            self.outputverifier.save_and_parse_output()
+            self.tray.reset_trays()
+            self.tray.unload_media()  # Will unload self.media from all trays
+            self.tray.load_media()  # Will load self.media in all trays to default
+
+            self.outputverifier.verify_media_source(Intents.printintent, MediaSource.main)
+            self.outputverifier.verify_media_size(Intents.printintent, MediaSize.a4)  # coming as a4 due to jpeg scaling
+
+            # CRC check
+            self.outputsaver.operation_mode('TIFF')
+            self.outputsaver.validate_crc_tiff(self.udw)
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+            self.outputsaver.operation_mode('NONE')

--- a/test_when_printing_jpeg_testimg.py
+++ b/test_when_printing_jpeg_testimg.py
@@ -1,0 +1,92 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg testimg Page from *testimg.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:testimg.jpg=ff6133bb58d3dae4f13ecbe05256dc4aaa05b17786b2c67f172cc3e934a00331
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testimg_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testimg
+            +guid:be094d37-29e9-418f-83a6-dfe01d7140ff
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testimg_then_succeeds(self):
+
+            expected_state = 'SUCCESS'
+
+            response = self.cdm.get(self.cdm.CDM_MEDIA_CAPABILITIES)
+
+            media_source= response['supportedInputs'][0]['mediaSourceId']
+            resolution = response['supportedInputs'][0]['resolution']
+            bottom_margin= response['supportedInputs'][0]['minimumPhysicalBottomMargin']/resolution
+            top_margin= response['supportedInputs'][0]['minimumPhysicalTopMargin']/resolution
+            left_margin= response['supportedInputs'][0]['minimumPhysicalLeftMargin']/resolution
+            right_margin= response['supportedInputs'][0]['minimumPhysicalRightMargin']/resolution
+            image_width=227/600  #Didn't have an option to get raw resolution of the image so using 600 as defualt resolution
+            image_height=149/600
+
+            if("roll" in media_source):
+                if(image_width<(left_margin+right_margin) or image_height<(top_margin+bottom_margin)):
+                    expected_state='FAILED'
+
+            job_id = self.print.raw.start('ff6133bb58d3dae4f13ecbe05256dc4aaa05b17786b2c67f172cc3e934a00331',expected_job_state=expected_state, timeout=120)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            logging.info("JPEG testimg Page- Print job completed successfully")

--- a/test_when_printing_jpeg_testimgp.py
+++ b/test_when_printing_jpeg_testimgp.py
@@ -1,0 +1,92 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg testimgp Page from *testimgp.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:testimgp.jpg=e9486e697b7082a324fe2812310303e13b0ddf67b073eacb4b9d8a53e50b7ea7
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testimgp_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testimgp
+            +guid:690a1c04-0011-4d5c-9bf0-e43402755235
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testimgp_then_succeeds(self):
+
+            expected_state = 'SUCCESS'
+
+            response = self.cdm.get(self.cdm.CDM_MEDIA_CAPABILITIES)
+
+            media_source= response['supportedInputs'][0]['mediaSourceId']
+            resolution = response['supportedInputs'][0]['resolution']
+            bottom_margin= response['supportedInputs'][0]['minimumPhysicalBottomMargin']/resolution
+            top_margin= response['supportedInputs'][0]['minimumPhysicalTopMargin']/resolution
+            left_margin= response['supportedInputs'][0]['minimumPhysicalLeftMargin']/resolution
+            right_margin= response['supportedInputs'][0]['minimumPhysicalRightMargin']/resolution
+            image_width=227/600  #Didn't have an option to get raw resolution of the image so using 600 as defualt resolution
+            image_height=149/600
+
+            if("roll" in media_source):
+                if(image_width<(left_margin+right_margin) or image_height<(top_margin+bottom_margin)):
+                    expected_state='FAILED'
+
+            job_id = self.print.raw.start('e9486e697b7082a324fe2812310303e13b0ddf67b073eacb4b9d8a53e50b7ea7',expected_job_state=expected_state, timeout=120)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            logging.info("JPEG testimgp Page- Print job completed successfully")

--- a/test_when_printing_jpeg_testorig.py
+++ b/test_when_printing_jpeg_testorig.py
@@ -1,0 +1,96 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg testorig Page from *testorig.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:testorig.jpg=acc6ec555d41d15b368320edaa3b20958ee6fa97cb6e4a18d1213d5ae8bec73b
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testorig_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testorig
+            +guid:289f6e4a-4b98-42de-883f-a6d66cfe88e4
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testorig_then_succeeds(self):
+
+            expected_state = 'SUCCESS'
+
+            response = self.cdm.get(self.cdm.CDM_MEDIA_CAPABILITIES)
+
+            media_source= response['supportedInputs'][0]['mediaSourceId']
+            resolution = response['supportedInputs'][0]['resolution']
+            bottom_margin= response['supportedInputs'][0]['minimumPhysicalBottomMargin']/resolution
+            top_margin= response['supportedInputs'][0]['minimumPhysicalTopMargin']/resolution
+            left_margin= response['supportedInputs'][0]['minimumPhysicalLeftMargin']/resolution
+            right_margin= response['supportedInputs'][0]['minimumPhysicalRightMargin']/resolution
+            image_width=227/600  #Didn't have an option to get raw resolution of the image so using 600 as defualt resolution
+            image_height=149/600
+
+            if("roll" in media_source):
+                if(image_width<(left_margin+right_margin) or image_height<(top_margin+bottom_margin)):
+                    expected_state='FAILED'
+
+            self.outputsaver.validate_crc_tiff(self.udw)
+            job_id = self.print.raw.start('acc6ec555d41d15b368320edaa3b20958ee6fa97cb6e4a18d1213d5ae8bec73b',expected_job_state=expected_state, timeout=120)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG testorig Page- Print job completed successfully")

--- a/test_when_printing_jpeg_testprog.py
+++ b/test_when_printing_jpeg_testprog.py
@@ -1,0 +1,95 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg testprog Page from *testprog.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:testprog.jpg=24770f706b81b40a71944af3b39aad8a3f7ffb21c4f2725447022e518222d823
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testprog_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testprog
+            +guid:8775816e-5b43-4867-a7db-7dc5aa1ee11b
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testprog_then_succeeds(self):
+            expected_state = 'SUCCESS'
+
+            response = self.cdm.get(self.cdm.CDM_MEDIA_CAPABILITIES)
+
+            media_source= response['supportedInputs'][0]['mediaSourceId']
+            resolution = response['supportedInputs'][0]['resolution']
+            bottom_margin= response['supportedInputs'][0]['minimumPhysicalBottomMargin']/resolution
+            top_margin= response['supportedInputs'][0]['minimumPhysicalTopMargin']/resolution
+            left_margin= response['supportedInputs'][0]['minimumPhysicalLeftMargin']/resolution
+            right_margin= response['supportedInputs'][0]['minimumPhysicalRightMargin']/resolution
+            image_width=227/600  #Didn't have an option to get raw resolution of the image so using 600 as defualt resolution
+            image_height=149/600
+
+            if("roll" in media_source):
+                if(image_width<(left_margin+right_margin) or image_height<(top_margin+bottom_margin)):
+                    expected_state='FAILED'
+
+            self.outputsaver.validate_crc_tiff(self.udw)
+            job_id = self.print.raw.start('24770f706b81b40a71944af3b39aad8a3f7ffb21c4f2725447022e518222d823',expected_job_state=expected_state, timeout=120)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG testprog Page- Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_100x100rgb.py
+++ b/test_when_printing_jpeg_testsuite_100x100rgb.py
@@ -1,0 +1,85 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite 100x100 rgb Page from *100x100rgb.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:100x100rgb.jpg=d5ac022cb1f519bf43576315cd62acb7dd7ba4de26bcd229fc544023a5da12ab
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_100x100rgb_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_100x100rgb
+            +guid:8edbde27-abb2-42ed-be2c-1da9cdafec31
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_100x100rgb_then_succeeds(self):
+            self.outputsaver.operation_mode('TIFF')
+
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported(default_size, default):
+                logging.info(f"Set paper tray <{default}> to paper size <{default_size}>")
+                self.tray.configure_tray(default, default_size, 'stationery')
+
+            job_id = self.print.raw.start('d5ac022cb1f519bf43576315cd62acb7dd7ba4de26bcd229fc544023a5da12ab', timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+
+            logging.info("JPEG TestSuite 100x100 rgb Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_3Dgirls_JFIF_nounits_without_EXIF.py
+++ b/test_when_printing_jpeg_testsuite_3Dgirls_JFIF_nounits_without_EXIF.py
@@ -1,0 +1,74 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite 3Dgirls JFIF nounits without EXIF Page from *3Dgirls_JFIF_nounits_without_EXIF.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:3Dgirls_JFIF_nounits_without_EXIF.jpg=07010aa839653b2355047c770f6f3631997e0e9172537141d42d185c34f39a1d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_3Dgirls_JFIF_nounits_without_EXIF_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_3Dgirls_JFIF_nounits_without_EXIF
+            +guid:fa33d931-c7b3-420c-ba1c-d6e3f3b327ce
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_3Dgirls_JFIF_nounits_without_EXIF_then_succeeds(self):
+            job_id = self.print.raw.start('07010aa839653b2355047c770f6f3631997e0e9172537141d42d185c34f39a1d')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            logging.info("JPEG TestSuite 3Dgirls JFIF nounits without EXIF Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_DemoImages.py
+++ b/test_when_printing_jpeg_testsuite_DemoImages.py
@@ -1,0 +1,74 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite DemoImages Page from *DemoImages.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:DemoImages.jpg=3c685134a542d477374788bb6a3f1027cd8f433d49a0255b2ac7f5246bd7010c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_DemoImages_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_DemoImages
+            +guid:dd131200-7de3-4149-9445-43445f821c03
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_DemoImages_then_succeeds(self):
+            job_id = self.print.raw.start('3c685134a542d477374788bb6a3f1027cd8f433d49a0255b2ac7f5246bd7010c', timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            logging.info("JPEG TestSuite DemoImages Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_J.py
+++ b/test_when_printing_jpeg_testsuite_J.py
@@ -1,0 +1,91 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite J Page from *J.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:J.jpg=010f60d2927a35d0235490136ef9f4953b7ee453073794bcaf153d20a64544ea
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_J_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_J
+            +guid:e37cb219-5a1c-45a7-b178-5c6559c12158
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_J_then_succeeds(self):
+            self.outputsaver.operation_mode('TIFF')
+            self.outputsaver.validate_crc_tiff(self.udw)
+
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('010f60d2927a35d0235490136ef9f4953b7ee453073794bcaf153d20a64544ea',timeout = 180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG TestSuite J Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_alt400mm_36inch_landscape.py
+++ b/test_when_printing_jpeg_testsuite_alt400mm_36inch_landscape.py
@@ -1,0 +1,92 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite alt400mm 36inch landscape Page from *alt400mm_36inch_landscape.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:alt400mm_36inch_landscape.jpg=8cb2e40ad94a931c43c9c6253ef7f367aa54cabf7b96a09a581c5b621fd00902
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_alt400mm_36inch_landscape_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_alt400mm_36inch_landscape
+            +guid:5a447aac-a2c5-40d4-8a68-d30bbbd57419
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+    
+
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_alt400mm_36inch_landscape_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+
+            job_id = self.print.raw.start('8cb2e40ad94a931c43c9c6253ef7f367aa54cabf7b96a09a581c5b621fd00902', timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG TestSuite alt400mm 36inch landscape Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_broken2.py
+++ b/test_when_printing_jpeg_testsuite_broken2.py
@@ -1,0 +1,83 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite broken2 Page from *broken2.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:broken2.jpg=746e460c805d937276f65426644ccb475358352a1cf5b7184a157650bcf3a9fc
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_broken2_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_broken2
+            +guid:53975145-8e48-44de-9f64-7a6e0419c0f8
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_broken2_then_succeeds(self):
+            default = self.tray.get_default_source()
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, 'anycustom', 'stationery')
+            elif self.tray.is_size_supported("custom", default) and self.tray.capabilities["supportedInputs"][0]["mediaLengthMaximum"] >= 150000:
+                # the size of print file should in max/min custom size of printer supported, then could set custom size
+                self.tray.configure_tray(default, "custom", 'stationery')
+
+            job_id = self.print.raw.start('746e460c805d937276f65426644ccb475358352a1cf5b7184a157650bcf3a9fc')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            self.tray.reset_trays()
+
+            logging.info("JPEG TestSuite broken2 Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_combo_SWOP_embedded.py
+++ b/test_when_printing_jpeg_testsuite_combo_SWOP_embedded.py
@@ -1,0 +1,78 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite combo SWOP embedded Page from *combo_SWOP_embedded.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:combo_SWOP_embedded.jpg=d9904a956bcf378816ff4f2c5c7ef8c6b8e03a68f7bcdad1aa0a47f218508b88
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_combo_SWOP_embedded_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_combo_SWOP_embedded
+            +guid:1e5eb3ad-e369-4a5d-8ffe-79161bef5a38
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_combo_SWOP_embedded_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+            job_id = self.print.raw.start('d9904a956bcf378816ff4f2c5c7ef8c6b8e03a68f7bcdad1aa0a47f218508b88')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG TestSuite combo SWOP embedded Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_combo_aRGB_embedded.py
+++ b/test_when_printing_jpeg_testsuite_combo_aRGB_embedded.py
@@ -1,0 +1,78 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite combo aRGB embedded Page from *combo_aRGB_embedded.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:combo_aRGB_embedded.jpg=50f412884b1ddafb50dcadf66349776bbdcdbdcaa219cda6da5bb84f1e2e7cc6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_combo_aRGB_embedded_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_combo_aRGB_embedded
+            +guid:7f14e5c7-39f2-4843-8d3c-8b11f7fb72d8
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_combo_aRGB_embedded_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+            job_id = self.print.raw.start('50f412884b1ddafb50dcadf66349776bbdcdbdcaa219cda6da5bb84f1e2e7cc6')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG TestSuite combo aRGB embedded Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_faces.py
+++ b/test_when_printing_jpeg_testsuite_faces.py
@@ -1,0 +1,78 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite faces Page from *faces.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:faces.jpg=d625c95d10545cc5aa1e4ce2f276a7d423c1aa96a683a581a4bc243ee93393a2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_faces_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_faces
+            +guid:4b4387b8-41ff-42cb-8528-41842cdcb1da
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_faces_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+            job_id = self.print.raw.start('d625c95d10545cc5aa1e4ce2f276a7d423c1aa96a683a581a4bc243ee93393a2', timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG TestSuite faces Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_faces_small.py
+++ b/test_when_printing_jpeg_testsuite_faces_small.py
@@ -1,0 +1,100 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType, MediaOrientation
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite faces small Page from *faces_small.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:faces_small.jpg=19d6b2e4af3faca6ef1c95c5750a3c8dea079b14a04a061cf4d2acdfaf2cb9fc
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_faces_small_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_faces_small
+            +guid:48fd8a11-adc9-41bc-a33e-12b4f326d772
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+    
+
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_faces_small_then_succeeds(self):
+            default = self.tray.get_default_source()
+            if self.print_emulation.print_engine_platform == 'emulator' and self.configuration.familyname == 'enterprise':
+                tray1 = MediaInputIds.Tray1.name
+                if self.tray.is_size_supported('anycustom', 'tray-1'):
+                    self.print_emulation.tray.open(tray1)
+                    self.print_emulation.tray.load(tray1, MediaSize.Custom.name, MediaType.Plain.name)
+                    self.print_emulation.tray.close(tray1)
+            else:
+                if self.tray.is_size_supported('anycustom', default):
+                    self.tray.configure_tray(default, 'anycustom', 'stationery')
+                else:
+                    self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('19d6b2e4af3faca6ef1c95c5750a3c8dea079b14a04a061cf4d2acdfaf2cb9fc')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.tray.reset_trays()
+
+            logging.info("JPEG TestSuite faces small Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_lenna_100_dpi.py
+++ b/test_when_printing_jpeg_testsuite_lenna_100_dpi.py
@@ -1,0 +1,87 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite lenna 100 dpi Page from *lenna_100_dpi.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:lenna_100_dpi.jpg=7a2e13bafa3b09a94ae8a5c92592c36f3104d8eb862dd121f505fd11262fc242
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_lenna_100_dpi_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_lenna_100_dpi
+            +guid:3e001bad-63d9-465d-8f39-8d48f171a859
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_lenna_100_dpi_then_succeeds(self):
+            self.outputsaver.operation_mode('TIFF')
+
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('7a2e13bafa3b09a94ae8a5c92592c36f3104d8eb862dd121f505fd11262fc242', timeout=300)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+
+            logging.info("JPEG TestSuite lenna 100 dpi Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_lenna_100_dpi_CMYK.py
+++ b/test_when_printing_jpeg_testsuite_lenna_100_dpi_CMYK.py
@@ -1,0 +1,91 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite lenna 100 dpi CMYK Page from *lenna_100_dpi_CMYK.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:lenna_100_dpi_CMYK.jpg=d96f65dbf236961108f2c22f547afc056967c2e26ff5928631108966bdb779c3
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_lenna_100_dpi_CMYK_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_lenna_100_dpi_CMYK
+            +guid:9f3a136c-5011-485d-a34e-b7388c30434b
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_lenna_100_dpi_CMYK_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('d96f65dbf236961108f2c22f547afc056967c2e26ff5928631108966bdb779c3', timeout=300)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+            self.tray.reset_trays()
+
+            logging.info("JPEG TestSuite lenna 100 dpi CMYK Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_lenna_100_dpi_EXIF_NONE.py
+++ b/test_when_printing_jpeg_testsuite_lenna_100_dpi_EXIF_NONE.py
@@ -1,0 +1,94 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite lenna 100 dpi EXIF NONE Page from *lenna_100_dpi_EXIF_NONE.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:lenna_100_dpi_EXIF_NONE.jpg=cc7efdcc505cf95c913aeafa9886ad5a4f2c31b4afefd35d9c9f5fd60f4368d3
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_lenna_100_dpi_EXIF_NONE_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_lenna_100_dpi_EXIF_NONE
+            +guid:0157a414-3f03-4b85-b754-6cd221bbf7f5
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+        +overrides:
+            +Home:
+                +is_manual:False
+                +timeout:240
+                +test:
+                    +dut:
+                        +type:Engine
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_lenna_100_dpi_EXIF_NONE_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('cc7efdcc505cf95c913aeafa9886ad5a4f2c31b4afefd35d9c9f5fd60f4368d3', timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+            self.tray.reset_trays()
+
+            logging.info("JPEG TestSuite lenna 100 dpi EXIF NONE Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_lenna_100_dpi_gray.py
+++ b/test_when_printing_jpeg_testsuite_lenna_100_dpi_gray.py
@@ -1,0 +1,90 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite lenna 100 dpi gray Page from *lenna_100_dpi_gray.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:lenna_100_dpi_gray.jpg=c3343a1bd344d4a992a05d2dac4c0c8203367d4e7e9aafa9fb835112b5d2729f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_lenna_100_dpi_gray_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_lenna_100_dpi_gray
+            +guid:edc6f9f2-6368-408b-bf9e-ae9663c0867f
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_lenna_100_dpi_gray_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('c3343a1bd344d4a992a05d2dac4c0c8203367d4e7e9aafa9fb835112b5d2729f', timeout=300)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+            self.tray.reset_trays()
+
+            logging.info("JPEG TestSuite lenna 100 dpi gray Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_lenna_20dpcm.py
+++ b/test_when_printing_jpeg_testsuite_lenna_20dpcm.py
@@ -1,0 +1,74 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite lenna 20dpcm Page from *lenna_20dpcm.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:lenna_20dpcm.jpg=be12e5937c270ec1d6690cc50cd3e42b1123f0d0fe04a6540e8c3ef19374c305
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_lenna_20dpcm_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_lenna_20dpcm
+            +guid:fe42720c-a04a-48a2-a842-63b1a93462b1
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_lenna_20dpcm_then_succeeds(self):
+            job_id = self.print.raw.start('be12e5937c270ec1d6690cc50cd3e42b1123f0d0fe04a6540e8c3ef19374c305', timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            logging.info("JPEG TestSuite lenna 20dpcm Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_lenna_20dpcm_EXIF_NONE.py
+++ b/test_when_printing_jpeg_testsuite_lenna_20dpcm_EXIF_NONE.py
@@ -1,0 +1,82 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite lenna 20dpcm EXIF NONE Page from *lenna_20dpcm_EXIF_NONE.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:200
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:lenna_20dpcm_EXIF_NONE.jpg=cb6e516bebfbd46c2e719ebb1bb3c7f4d49cefb80977a40cc167073712f7ba24
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_lenna_20dpcm_EXIF_NONE_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_lenna_20dpcm_EXIF_NONE
+            +guid:df7798fe-450e-4268-96b3-54f581d20db3
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_lenna_20dpcm_EXIF_NONE_then_succeeds(self):
+            default = self.tray.get_default_source()
+            default_size = self.tray.get_default_size(default)
+
+            if self.tray.is_size_supported(default_size, default):
+                logging.info(f"Set paper tray <{default}> to paper size <{default_size}>")
+                self.tray.configure_tray(default, default_size, 'stationery')
+
+            job_id = self.print.raw.start('cb6e516bebfbd46c2e719ebb1bb3c7f4d49cefb80977a40cc167073712f7ba24', timeout=180)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.tray.reset_trays()
+
+            logging.info("JPEG TestSuite lenna 20dpcm EXIF NONE Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_lenna_without_resolution_info.py
+++ b/test_when_printing_jpeg_testsuite_lenna_without_resolution_info.py
@@ -1,0 +1,88 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite lenna without resolution info Page from *lenna_without_resolution_info.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:420
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:lenna_without_resolution_info.jpg=e1ed76315e7bfc2c48c28b1efb0fbd0a3b28c333583ce6b477cfcc7da495042c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_lenna_without_resolution_info_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_lenna_without_resolution_info
+            +guid:80530243-a292-41ff-a8d4-4c61feff2c6b
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_lenna_without_resolution_info_then_succeeds(self):
+            self.outputsaver.operation_mode('TIFF')
+            self.outputsaver.validate_crc_tiff(self.udw)
+            default = self.tray.get_default_source()
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('e1ed76315e7bfc2c48c28b1efb0fbd0a3b28c333583ce6b477cfcc7da495042c',timeout=420)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            self.tray.reset_trays()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG TestSuite lenna without resolution info Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_lenna_without_resolution_info_EXIF_NONE.py
+++ b/test_when_printing_jpeg_testsuite_lenna_without_resolution_info_EXIF_NONE.py
@@ -1,0 +1,90 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.print_common_types import MediaSize, MediaType
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite lenna without resolution info EXIFNONE Page from *lenna_without_resolution_info_EXIF_NONE.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:420
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:lenna_without_resolution_info_EXIF_NONE.jpg=0bfd0d031132cc8326b33ae0aaeff9df4d1fe2ddcf42c208c2842a80ae922c19
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_lenna_without_resolution_info_EXIF_NONE_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_lenna_without_resolution_info_EXIF_NONE
+            +guid:31967c5b-1079-44c7-bca8-7c7a81066791
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_lenna_without_resolution_info_EXIF_NONE_then_succeeds(self):
+            self.outputsaver.validate_crc_tiff(self.udw)
+            default = self.tray.get_default_source()
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, "anycustom", 'stationery')
+            elif self.tray.is_size_supported('any', default):
+                tray_test_name = self.print_mapper.get_media_input_test_name(default)
+                self.print_emulation.tray.setup_tray(tray_test_name, MediaSize.Letter.name, MediaType.Plain.name)
+                self.tray.configure_tray(default, 'any', 'any')
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+
+            job_id = self.print.raw.start('0bfd0d031132cc8326b33ae0aaeff9df4d1fe2ddcf42c208c2842a80ae922c19',timeout=420)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            self.tray.reset_trays()
+            Current_crc_value = self.outputsaver.get_crc()
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+            logging.info("JPEG TestSuite lenna without resolution info EXIF NONE Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_parrots_Progressive_Interlaced.py
+++ b/test_when_printing_jpeg_testsuite_parrots_Progressive_Interlaced.py
@@ -1,0 +1,95 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+from dunetuf.print.print_common_types import MediaSize, MediaType
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:C52178010 Simple print job of Jpeg TestSuite parrots Progressive Interlaced Page from *parrots_Progressive_Interlaced.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:660
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:parrots_Progressive_Interlaced.jpg=dfcaa88adf10d6833f97280b5a58893db02845db6c41495cd324ccb1145bda9a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_parrots_Progressive_Interlaced_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_parrots_Progressive_Interlaced
+            +guid:b98580dc-6267-4698-8f74-ab6e05916f49
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+        +overrides:
+            +Home:
+                +is_manual:False
+                +timeout:660
+                +test:
+                    +dut:
+                        +type:Engine
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_parrots_Progressive_Interlaced_then_succeeds(self):
+            # Print file size : width 10.67 inches and height 7.11 inches
+            default = self.tray.get_default_source()
+            if self.tray.is_size_supported('anycustom', default):
+                self.tray.configure_tray(default, 'anycustom', 'stationery')
+            elif self.tray.is_size_supported('any', default):
+                tray_test_name = self.print_mapper.get_media_input_test_name(default)
+                self.print_emulation.tray.setup_tray(tray_test_name, MediaSize.Letter.name, MediaType.Plain.name)
+                self.tray.configure_tray(default, 'any', 'any')
+            else:
+                self.tray.configure_tray(default, 'custom', 'stationery')
+            self.outputsaver.validate_crc_tiff(self.udw) 
+            job_id = self.print.raw.start('dfcaa88adf10d6833f97280b5a58893db02845db6c41495cd324ccb1145bda9a', timeout=600)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+            logging.info("Get crc value for the current print job")
+            Current_crc_value = self.outputsaver.get_crc() 
+            logging.info("Validate current crc with master crc")
+            assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+            self.tray.reset_trays()
+            logging.info("JPEG TestSuite parrots Progressive Interlaced Page - Print job completed successfully")

--- a/test_when_printing_jpeg_testsuite_taggedRGB.py
+++ b/test_when_printing_jpeg_testsuite_taggedRGB.py
@@ -1,0 +1,101 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Jpeg TestSuite taggedRGB Page from *taggedRGB.jpg file
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:300
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:taggedRGB.jpg=34027bf1e1808b1cf5995aedea2a805a35b12f77eb725ebb44dc662715fc295c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_testsuite_taggedRGB_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_testsuite_taggedRGB
+            +guid:eca4285c-f468-440a-958b-e2fbb388255a
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+    
+
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_testsuite_taggedRGB_then_succeeds(self):
+            expected_state = 'SUCCESS'
+
+            response = self.cdm.get(self.cdm.CDM_MEDIA_CAPABILITIES)
+
+            media_source= response['supportedInputs'][0]['mediaSourceId']
+            resolution = response['supportedInputs'][0]['resolution']
+            bottom_margin= response['supportedInputs'][0]['minimumPhysicalBottomMargin']/resolution
+            top_margin= response['supportedInputs'][0]['minimumPhysicalTopMargin']/resolution
+            left_margin= response['supportedInputs'][0]['minimumPhysicalLeftMargin']/resolution
+            right_margin= response['supportedInputs'][0]['minimumPhysicalRightMargin']/resolution
+            image_width=499/600  #Didn't have an option to get raw resolution of the image so using 600 as defualt resolution
+            image_height=202/600
+
+            if("roll" in media_source):
+                if(image_width<(left_margin+right_margin) or image_height<(top_margin+bottom_margin)):
+                    expected_state='FAILED'
+            job_id = self.print.raw.start('34027bf1e1808b1cf5995aedea2a805a35b12f77eb725ebb44dc662715fc295c', expected_job_state=expected_state)
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()
+
+            logging.info("JPEG TestSuite taggedRGB Page - Print job completed successfully")

--- a/test_when_printing_jpeg_webpage_upd_print.py
+++ b/test_when_printing_jpeg_webpage_upd_print.py
@@ -1,0 +1,72 @@
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.print.print_new import Print
+import logging
+
+class TestWhenPrintingJPEGFile():
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    def teardown_method(self):
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        #TODO: Create job_history methods in Ares
+        #self.job_history.clear()
+        #self.job_history.wait_for_history_empty()
+
+    """
+
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Jpeg test using **Webpage_UPD_PRint.JPG
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-17136
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:Webpage_UPD_PRint.JPG=a89ef72d5101dabbf55a0722d57141626372518bfd7fa6b3ba53808ba7d1e0f5
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_webpage_upd_print_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:JPEG
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_jpeg_webpage_upd_print
+            +guid:9879404e-8d7e-4072-b20a-085d2e7c1852
+            +dut:
+                +type:Simulator
+                +configuration:DocumentFormat=JPEG
+    
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+
+    """
+    def test_when_using_webpage_upd_print_then_succeeds(self):
+            job_id = self.print.raw.start('a89ef72d5101dabbf55a0722d57141626372518bfd7fa6b3ba53808ba7d1e0f5')
+            # Wait for copy job to complete
+            self.print.wait_for_state(job_id, ["completed"])
+            self.outputsaver.save_output()


### PR DESCRIPTION
## Summary
- create `test_when_printing_jpeg_*` files for each existing JPEG test
- use new `TestWhenPrintingJPEGFile` class with updated metadata and print calls
- rename methods to `test_when_using_*_then_succeeds`
- access fixtures via instance attributes
- indent metadata consistently

## Testing
- `python -m compileall -q test_when_printing_jpeg_*.py`

------
https://chatgpt.com/codex/tasks/task_e_686a7d8d704483328c3cf4e2f07ac1ce